### PR TITLE
Request for Comment: New helper functions

### DIFF
--- a/core/src/main/kotlin/br/com/gamemods/minecity/core/helpers/Reflection.kt
+++ b/core/src/main/kotlin/br/com/gamemods/minecity/core/helpers/Reflection.kt
@@ -1,0 +1,42 @@
+package br.com.gamemods.minecity.core.helpers
+
+import kotlin.reflect.KClass
+import kotlin.reflect.full.isSubclassOf
+
+/**
+ * Checks if an object **is** an instance of **ANY** of the classes given.
+ * @param types A list of [KClass] that will be checked.
+ *
+ * The following code examples are equivalent.
+ * ```kt
+ * obj is TypeA || obj is TypeB
+ * obj.isInstanceOfAny(TypeA::class, TypeB::class)
+ * ```
+ * @author alikindsys
+ */
+fun Any.isInstanceOfAny(vararg types: KClass<*>): Boolean {
+    // Short-circuiting on a list based on an OR operation.
+    for (cls in types) {
+        // ⊤ OR { ⊥,⊤ } = ⊤
+        // { ⊥,⊤ } OR ⊥ = { ⊥,⊤ }
+        if (this::class.isSubclassOf(cls)) return true
+    }
+    // ⊥ OR ⊥ = ⊥
+    return false
+}
+
+/**
+ * Checks if an object **is NOT** an instance of **ALL** the classes given.
+ * @param types A list of [KClass] that will be .
+ *
+ * The following code examples are equivalent.
+ * ```kt
+ * obj !is TypeA && obj !is TypeB
+ * obj.isInstanceOfNone(TypeA::class, TypeB::class)
+ * ```
+ * @author alikindsys
+ */
+fun Any.isInstanceOfNone(vararg types: KClass<*>): Boolean {
+    // !(P OR Q) = (!P AND !Q)
+    return !this.isInstanceOfAny(*types)
+}

--- a/platform/fabric/src/main/kotlin/br/com/gamemods/minecity/fabric/helpers/Permission.kt
+++ b/platform/fabric/src/main/kotlin/br/com/gamemods/minecity/fabric/helpers/Permission.kt
@@ -1,0 +1,25 @@
+package br.com.gamemods.minecity.fabric.helpers
+
+import br.com.gamemods.minecity.api.claim.Claim
+import br.com.gamemods.minecity.api.id.ClaimPermissionId
+import br.com.gamemods.minecity.api.serializer.UniqueId
+import net.minecraft.util.ActionResult
+
+/**
+ * Checks if a [UniqueId] has a given [ClaimPermissionId] inside a [Claim].
+ *
+ * *Note*: This is platform-dependent code since each loader treats [ActionResult]s differently.
+ * This code is **expected to work with Fabric API**'s event system.
+ * @param claim The claim being checked. Usually the one the player is located at.
+ * @param permissionId The [ClaimPermissionId] of the permission. E.g. [ClaimPermissionId.BUILD].
+ * @return An [ActionResult.PASS] if the player **has** the permission. An [ActionResult.FAIL] if the player **doesn't** have the permission.
+ * @see [ClaimPermissionId]
+ * @author alikindsys
+ */
+fun UniqueId.hasPermissionIn(claim: Claim, permissionId: ClaimPermissionId): ActionResult {
+    return if (claim.hasPermission(this, permissionId)) {
+        ActionResult.PASS
+    } else {
+        ActionResult.FAIL
+    }
+}

--- a/platform/fabric/src/main/kotlin/br/com/gamemods/minecity/fabric/helpers/WorldAccess.kt
+++ b/platform/fabric/src/main/kotlin/br/com/gamemods/minecity/fabric/helpers/WorldAccess.kt
@@ -1,0 +1,31 @@
+package br.com.gamemods.minecity.fabric.helpers
+
+import net.minecraft.block.BlockState
+import net.minecraft.block.entity.BlockEntity
+import net.minecraft.util.hit.BlockHitResult
+import net.minecraft.world.World
+
+/**
+ * Gets a [BlockState] from a [BlockHitResult] by accessing a [World]
+ *
+ * You *should* have a reference to a world on which this [BlockHitResult] was queried.
+ *
+ * **Trivial**: This is a mere convenience extension function.
+ * @param world The world being queried.
+ * @author alikindsys
+ */
+fun BlockHitResult.blockStateBy(world: World) : BlockState {
+    return world.getBlockState(this.blockPos)
+}
+
+/**
+ * Gets a [BlockEntity] from a [BlockHitResult] by accessing a [World]
+ *
+ * You *should* have a reference to a world on which this [BlockHitResult] was queried.
+ *
+ * **Trivial**: This is a mere convenience extension function.
+ * @param world The world being queried.
+ * @author alikindsys
+ */fun BlockHitResult.blockEntityBy(world: World) : BlockEntity? {
+    return world.getBlockEntity(this.blockPos)
+}

--- a/platform/fabric/src/main/kotlin/br/com/gamemods/minecity/fabric/helpers/WorldAccess.kt
+++ b/platform/fabric/src/main/kotlin/br/com/gamemods/minecity/fabric/helpers/WorldAccess.kt
@@ -26,6 +26,7 @@ fun BlockHitResult.blockStateBy(world: World) : BlockState {
  * **Trivial**: This is a mere convenience extension function.
  * @param world The world being queried.
  * @author alikindsys
- */fun BlockHitResult.blockEntityBy(world: World) : BlockEntity? {
+ */
+ fun BlockHitResult.blockEntityBy(world: World) : BlockEntity? {
     return world.getBlockEntity(this.blockPos)
 }


### PR DESCRIPTION
While implementing PC-1051 I noticed some easily extractable patterns from looking at the other existing implementations (only `FabricDoorPermission` at the time) and turned those into helper functions.

Of note is `isInstanceOfAny` and `isInstanceOfNone`, which were used during the implementation of PC-1051 in order to simplify the `object !is A && object !is B && object !is C ...` repetition.

Another thing I found useful was extracting the conversion from `claim.hasPermission(player.identity().uuid(), permissionId)` into `ActionResult`s, since that code *will* get repeated with little to no changes in code for every single permission.

The last set of helpers act on getting `Block|BlockState` information from a `BlockHitResult`, provided you have a world instance where that happens (which should be always).

I hope these are as helpful to you as it were to us while developing PC-1051. 

An example for using this new API can be found on: #4, which is where they origined from.