### PR TITLE
Fix wrong ActionResult on FabricDoorClaimPermission

### DIFF
--- a/platform/fabric/src/main/kotlin/br/com/gamemods/minecity/fabric/service/permission/FabricDoorClaimPermission.kt
+++ b/platform/fabric/src/main/kotlin/br/com/gamemods/minecity/fabric/service/permission/FabricDoorClaimPermission.kt
@@ -41,7 +41,7 @@ class FabricDoorClaimPermission: ClaimPermission(
             val block = blockState.block
 
             if (block !is DoorBlock && block !is TrapdoorBlock) {
-                return ActionResult.SUCCESS
+                return ActionResult.PASS
             }
 
             val claim = MineCity.claims[world, clickPos] ?: return ActionResult.PASS


### PR DESCRIPTION
`ActionResult.SUCCESS` is used to indicate to FabricAPI that *all processing is done*, since it "cancels further processing".

Although it might seem that this is what you want to convey, unfortunately since it cancels ALL further processing, the first callback to get that event from the queue consumes it, and all the logic that should follow that is blocked from ever existing.

The most common (and visible) side effect is the complete inability to place any blocks in the world, even though this permission should only ever check for block interactions not new blocks being placed.

Placing blocks is another permission entirely, and since this is a clear overreach of `FabricDoorClaimPermission`, which should only "Allow the player to open and close doors in the claim."